### PR TITLE
fix:coluna 'ultimas notícias' dentro de uma notícia. 

### DIFF
--- a/src/_includes/post-grid-mini-latest-news.html
+++ b/src/_includes/post-grid-mini-latest-news.html
@@ -1,0 +1,17 @@
+<div class="mb-3 ">
+    <div class="h-full border-2 border-gray-200 border-opacity-60 rounded-lg overflow-hidden">
+        <img class="lg:h-48 md:h-36 w-full object-cover object-center" src="{{ site.url }}{{ post.image.feature }}" alt="blog">
+        <div class="p-6">
+            <h1 class="title-font text-lg font-medium text-gray-900 mb-3">{{ post.title }}</h1>
+            <div class="flex items-center flex-wrap ">
+                <a href="{{ site.url }}{{ post.url }}" class="text-indigo-500 inline-flex items-center md:mb-2 lg:mb-0">Saber mais
+                    <svg class="w-4 h-4 ml-2" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M5 12h14"></path>
+                        <path d="M12 5l7 7-7 7"></path>
+                    </svg>
+                </a>
+            </div>
+        </div>
+    </div>
+</div>
+

--- a/src/_layouts/article.html
+++ b/src/_layouts/article.html
@@ -2,7 +2,31 @@
 layout: default
 ---
 
-<div id="main" role="main">
+
+<style>
+
+@media screen and (min-width: 56.25em) {
+    #main .inner-wrap {
+        margin-right: 3.35765%;
+        width: 75%;
+    }
+
+}
+
+#main .page-title {
+	text-align: center;
+}
+
+
+.wrap {
+    max-width: 90em;
+}
+
+
+</style>
+
+
+<div id="main" role="main" >
 	<article class="wrap text-justify" itemscope itemtype="http://schema.org/Article" style="margin-top: 90px;">
 		{% if page.image.feature %}
 		<div class="page-feature">
@@ -14,8 +38,8 @@ layout: default
 		{% endif %}
 		{% include breadcrumbs.html %}
 		<div class="page-title">
-			<h1>{{ page.title }}</h1>
-			{% include page-meta.html %}
+			<h1 class="mb-3">{{ page.title }}</h1>
+			<i>{% include page-meta.html %}</i>
 		</div>
 		<div class="inner-wrap">
 			<div id="content" itemprop="articleBody">
@@ -41,7 +65,7 @@ layout: default
 				<div class="row">
 				  <div class="col-12 text-left">
 					{% for post in site.categories.noticias limit: 2 %}
-						{% include post-grid-mini.html %}
+						{% include post-grid-mini-latest-news.html %}
 					{% endfor %}
 				  </div>
 				</div>


### PR DESCRIPTION
Corrigido o problema da coluna 'últimas noticias' dentro de um noticia.
- As noticias eram importadas através do arquivo _post-grid-mini.html_. Como esse arquivo era utilizado em outras partes do site, foi necessário criar outro arquivo _post-grid-mini-latest-news.html_ e fazer algumas modificações. 
- No arquivo  _article.html_ foi alterado a estilização da página de noticias. Foi aumentado a largura da pagina e da coluna 'ultimas noticias' e o titulo foi centralizado junto com a data de publicação da noticia. 
 



[![UQvtF2.md.png](https://iili.io/UQvtF2.md.png)](https://freeimage.host/i/UQvtF2)


